### PR TITLE
Update number of VPA modes in readme

### DIFF
--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -130,7 +130,7 @@ resource requests for your pods.
 In order to use it you need to insert a *Vertical Pod Autoscaler* resource for
 each controller that you want to have automatically computed resource requirements.
 This will be most commonly a **Deployment**.
-There are three modes in which *VPAs* operate:
+There are four modes in which *VPAs* operate:
 
 * `"Auto"`: VPA assigns resource requests on pod creation as well as updates
   them on existing pods using the preferred update mechanism. Currently this is


### PR DESCRIPTION

#### Which component this PR applies to?

README

#### What type of PR is this?

/kind documentation


#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

As seen [here](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go#L126-L143), we have now four modes hence the documentation should get updated.

Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

NONE
